### PR TITLE
SVG dependency update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,5 @@ repository = "https://github.com/askanium/rustplotlib"
 readme = "README.md"
 
 [dependencies]
-svg="0.7.1"
+svg="0.13.0"
 format_num = "0.1.0"

--- a/src/chart.rs
+++ b/src/chart.rs
@@ -1,7 +1,6 @@
 use std::string::ToString;
 use std::ffi::OsStr;
 use std::path::Path;
-use svg;
 use svg::node::element::Group;
 use svg::Node;
 use svg::node::Text as TextNode;
@@ -278,7 +277,7 @@ impl<'a> Chart<'a> {
             .set("class", "g-chart");
 
         // Add chart title
-        if self.title.len() > 0 {
+        if !self.title.is_empty() {
             let title_group = Group::new()
                 .set("class", "g-title")
                 .set("transform", format!("translate({},{})", self.width / 2, 25))
@@ -336,7 +335,7 @@ impl<'a> Chart<'a> {
             match legend_position {
                 AxisPosition::Top => {
                     let axis_height = {
-                        if self.title.len() > 0 {
+                        if !self.title.is_empty() {
                             45
                         } else {
                             10

--- a/src/scales/linear.rs
+++ b/src/scales/linear.rs
@@ -79,7 +79,7 @@ impl ScaleLinear {
         };
 
         let step = match power.cmp(&0) {
-            Ordering::Less => -10_f32.powi(-power) / dynamic as f32,
+            Ordering::Less => -(10_f32.powi(-power)) / dynamic as f32,
             _ => dynamic as f32 * 10_f32.powi(power),
         };
 


### PR DESCRIPTION
* Updates SVG dependency
* checks missing chart title with `self.title.is_empty()` method instead of `self.title.len() > 0`
*  fixes linear scale ordering